### PR TITLE
Revert "Bump kramdown from 2.1.0 to 2.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
-      rexml
+    kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
@@ -56,7 +55,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rexml (3.2.4)
     rouge (3.11.1)
     safe_yaml (1.0.5)
     sassc (2.2.1)


### PR DESCRIPTION
Reverts wapiflapi/wapiflapi.github.io#1

We're getting page build failure on the master branch after that security update.

I don't think the templating issue is problem for the way it is used to build the STATIC code to deploy to github.io.